### PR TITLE
fix Notice when add new comment

### DIFF
--- a/lib/Gitlab/Model/Note.php
+++ b/lib/Gitlab/Model/Note.php
@@ -38,7 +38,8 @@ class Note extends AbstractModel
      */
     public static function fromArray(Client $client, Noteable $type, array $data)
     {
-        $comment = new static($type, $data['id'], $client);
+        $id = isset($data['id']) ? $data['id'] : null;
+        $comment = new static($type, $id, $client);
 
         if (isset($data['author'])) {
             $data['author'] = User::fromArray($client, $data['author']);


### PR DESCRIPTION
Notice: Undefined index: id in /.../vendor/m4tthumphrey/php-gitlab-api/lib/Gitlab/Model/Note.php on line 42

Call Stack:
    [...]
    0.4737    3273000   8. Gitlab\Model\MergeRequest->addComment() /home/vagrant/git/m-runner/index.php:44
    0.6070    3290696   9. Gitlab\Model\Note::fromArray() /home/vagrant/git/m-runner/vendor/m4tthumphrey/php-gitlab-api/lib/Gitlab/Model/MergeRequest.php:188
